### PR TITLE
Update codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,9 +28,7 @@ jobs:
       - name: Test and Create Coverage Report
         run: |
           make test-unit-cover
-        if: env.GIT_DIFF
       - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.txt
           fail_ci_if_error: true
-        if: env.GIT_DIFF

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,12 +25,6 @@ jobs:
           go-version: '1.20'
           check-latest: true
       - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.1.2
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: Test and Create Coverage Report
         run: |
           make test-unit-cover


### PR DESCRIPTION
using get-diff-action can mask important failures from time to time, so we shouldn't use it