### PR TITLE
add mvdan's multiplatform go test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+# https://github.com/mvdan/github-actions-golang
+# a Go test runner that runs tests on two releases of Go for every platform.
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.19.x, 1.20.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+    - run: go test ./...


### PR DESCRIPTION
This PR adds mvdan's multiplatform go test runner.  It will help us to know that realio works with:

go 1.19 (mac, windows, linux)
go 1.20 (mac, windows, linux)


