### PR TITLE
feat: add berlin precompiles to memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+- (evm) [#212](https://github.com/realiotech/realio-network/pull/212): Add Berlin precomiles to memory
+
 ### Improvements
 
 - (chore) [#211](https://github.com/realiotech/realio-network/pull/211): Update changelog from v1.0.1

--- a/app/app.go
+++ b/app/app.go
@@ -39,6 +39,7 @@ import (
 	osecp256k1 "github.com/evmos/os/crypto/ethsecp256k1"
 	srvflags "github.com/evmos/os/server/flags"
 	ostypes "github.com/evmos/os/types"
+	evmosvm "github.com/evmos/os/x/evm/core/vm"
 
 	"github.com/evmos/os/x/evm"
 	evmkeeper "github.com/evmos/os/x/evm/keeper"
@@ -479,6 +480,8 @@ func New(
 		app.AccountKeeper, app.BankKeeper, app.StakingKeeper, app.FeeMarketKeeper, MockErc20Keeper{},
 		tracer, app.GetSubspace(evmtypes.ModuleName),
 	)
+
+	app.EvmKeeper.WithStaticPrecompiles(evmosvm.PrecompiledContractsBerlin)
 
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks


### PR DESCRIPTION
[RP-4037](https://realio.atlassian.net/browse/RP-4037)

Currently in Evmos, precompiles that were active at the Berlin hard fork are enabled by default on Evmos besides other precompiles that are extended through module params. This is handle [here](https://github.com/evmos/os/blob/bf18711360cd5852925d1df43e053505e0f0dc52/x/evm/keeper/static_precompiles.go#L48). 

However, our tests are currently failing [here](https://github.com/evmos/os/blob/bf18711360cd5852925d1df43e053505e0f0dc52/x/evm/keeper/static_precompiles.go#L36). This is because the static precompiles are not found in memory within the keeper.

Evmos requires static precompiles to be stored in memory for efficiency (not having to query the params on every transaction). To do this, they have to be instantiated in `app.go` through [this](https://github.com/evmos/os/blob/bf18711360cd5852925d1df43e053505e0f0dc52/x/evm/keeper/static_precompiles.go#L16) function. 

[RP-4037]: https://realio.atlassian.net/browse/RP-4037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ