### PR TITLE
RegisterConcrete evmos/os keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (fix) [#258](https://github.com/realiotech/realio-network/pull/258): Add missing items and fix upgrade v1.3.0
 
+- (codec) [#259](https://github.com/realiotech/realio-network/pull/259): evmos/os keys codec
+
 # [v1.3.0]
 
 ### State Machine Breaking

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -53,6 +53,7 @@ func MakeEncodingConfig() params.EncodingConfig {
 	evmcryptocodec.RegisterInterfaces(interfaceRegistry)
 	ethcryptocodec.RegisterCrypto(legacyAmino)
 	ethcryptocodec.RegisterInterfaces(interfaceRegistry)
+	ossecp256k1.RegisterCrypto(legacyAmino)
 	ossecp256k1.RegisterInterfaces(interfaceRegistry)
 
 	// This is needed for the EIP712 txs because currently is using

--- a/crypto/ossecp256k1/codec.go
+++ b/crypto/ossecp256k1/codec.go
@@ -3,6 +3,8 @@
 package ossecp256k1
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
@@ -11,4 +13,15 @@ import (
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*cryptotypes.PubKey)(nil), &PubKey{})
 	registry.RegisterImplementations((*cryptotypes.PrivKey)(nil), &PrivKey{})
+}
+
+// RegisterCrypto registers all crypto dependency types with the provided Amino
+// codec.
+func RegisterCrypto(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&PubKey{}, PubKeyName, nil)
+	cdc.RegisterConcrete(&PrivKey{}, PrivKeyName, nil)
+
+	// NOTE: update SDK's amino codec to include the ethsecp256k1 keys.
+	// DO NOT REMOVE unless deprecated on the SDK.
+	legacy.Cdc = cdc
 }

--- a/crypto/ossecp256k1/ethsecp256k1.go
+++ b/crypto/ossecp256k1/ethsecp256k1.go
@@ -30,9 +30,9 @@ const (
 // Amino encoding names
 const (
 	// PrivKeyName defines the amino encoding name for the EthSecp256k1 private key
-	PrivKeyName = "os/PrivKeyEthSecp256k1"
+	PrivKeyName = "evmos/PrivKeyEthSecp256k1"
 	// PubKeyName defines the amino encoding name for the EthSecp256k1 public key
-	PubKeyName = "os/PubKeyEthSecp256k1"
+	PubKeyName = "evmos/PubKeyEthSecp256k1"
 )
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
- Since evmos/os and cosmos/evm keys have same names, need to rename the os keys
```go
        // PrivKeyName defines the amino encoding name for the EthSecp256k1 private key
	PrivKeyName = "os/PrivKeyEthSecp256k1"
	// PubKeyName defines the amino encoding name for the EthSecp256k1 public key
	PubKeyName = "os/PubKeyEthSecp256k1"
```