### PR TITLE
Migrate feemarket params

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -81,6 +81,7 @@ func (app *RealioNetwork) setupUpgradeHandlers() {
 			app.configurator,
 			app.AccountKeeper,
 			*app.EvmKeeper,
+			app.FeeMarketKeeper,
 		),
 	)
 

--- a/app/upgrades/v1.3/upgrades.go
+++ b/app/upgrades/v1.3/upgrades.go
@@ -67,7 +67,6 @@ func migrateEVMParams(sdkCtx sdk.Context, vm module.VersionMap, evmKeeper evmkee
 	}
 
 	feemarketParams := feemarketKeeper.GetParams(sdkCtx)
-	feemarketParams.BaseFee = math.LegacyMustNewDecFromStr("7.000000000000000000")
 	feemarketParams.MinGasPrice = math.LegacyMustNewDecFromStr("7.000000000000000000")
 	err = feemarketKeeper.SetParams(sdkCtx, feemarketParams)
 	if err != nil {


### PR DESCRIPTION
since `MinGasPrice` types migrate from `Int` to `LegacyDec`, we need to update feemarket params.MinGasPrice as BaseFee lower bound so it never reduce to zero 