### PR TITLE
Fix: increase `multistaking` precompile gas

### DIFF
--- a/precompile/multistaking/multistaking.go
+++ b/precompile/multistaking/multistaking.go
@@ -58,13 +58,11 @@ func NewPrecompile(
 		return nil, err
 	}
 
-	// NOTE: we set an empty gas configuration to avoid extra gas costs
-	// during the run execution
 	p := &Precompile{
 		Precompile: cmn.Precompile{
 			ABI:                  newABI,
-			KvGasConfig:          storetypes.GasConfig{},
-			TransientKVGasConfig: storetypes.GasConfig{},
+			KvGasConfig:          storetypes.KVGasConfig(),
+			TransientKVGasConfig: storetypes.TransientGasConfig(),
 		},
 		Codec:              cdc,
 		stakingKeeper:      stakingKeeper,


### PR DESCRIPTION
There is a gas difference between evm txs calls to `multistaking` precompile and cosmos txs. Use default gas config instead of empty.