### PR TITLE
test: Integration test for `RemoveMultistakingBondDenom`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -256,14 +256,14 @@ require (
 
 replace (
 	github.com/cosmos/evm => github.com/realiotech/evm v0.2.1
-	// github.com/realio-tech/multi-staking-module => ../multi-staking
 	// use Cosmos geth fork
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.10.26-evmos-rc4.0.20250402013457-cf9d288f0147
 
 	// use cosmos flavored protobufs
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	// github.com/realio-tech/multi-staking-module => ../multi-staking-ori
 
-	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0-rc1
+	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0-rc2-test
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,7 @@ replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	// github.com/realio-tech/multi-staking-module => ../multi-staking-ori
 
-	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0-rc2-test
+	github.com/realio-tech/multi-staking-module => github.com/realiotech/multi-staking v1.1.0-rc3
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/realiotech/evm v0.2.1 h1:XEoLoiWwsZ23Zp6xgFf48bxTm2bQXfsvxN8nQSg/LKA=
 github.com/realiotech/evm v0.2.1/go.mod h1:/4D24vd1xRnUVaXzfNryxTo5Gn1c/phJG5FvpH9OvLQ=
-github.com/realiotech/multi-staking v1.1.0-rc2-test h1:E/oT7xvBPT/SgRbTXJ3NdPsrjUMXvptmuXNUuHDWAIs=
-github.com/realiotech/multi-staking v1.1.0-rc2-test/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
+github.com/realiotech/multi-staking v1.1.0-rc3 h1:DfG8NMOGjj2EKSpbSUOzklb5A3R7Y0SixMM6DUdbUyQ=
+github.com/realiotech/multi-staking v1.1.0-rc3/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1 h1:OHEc+q5iIAXpqiqFKeLpu5NwTIkVXUs48vFMwzqpqY4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1/go.mod h1:2DjTFR1HhMQhiWC5sZ4OhQ3+NtdbZ6oBDKQwq5Ou+FI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/realiotech/evm v0.2.1 h1:XEoLoiWwsZ23Zp6xgFf48bxTm2bQXfsvxN8nQSg/LKA=
 github.com/realiotech/evm v0.2.1/go.mod h1:/4D24vd1xRnUVaXzfNryxTo5Gn1c/phJG5FvpH9OvLQ=
-github.com/realiotech/multi-staking v1.1.0-rc1 h1:fv/NiVyTbr+umXq0Mi+8UvqdY33xQCiygjxd5KpvIes=
-github.com/realiotech/multi-staking v1.1.0-rc1/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
+github.com/realiotech/multi-staking v1.1.0-rc2-test h1:E/oT7xvBPT/SgRbTXJ3NdPsrjUMXvptmuXNUuHDWAIs=
+github.com/realiotech/multi-staking v1.1.0-rc2-test/go.mod h1:jNjSslDy7t9OozYsFShqRmjPrKCQV6Do4VhXRKYmh2A=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1 h1:OHEc+q5iIAXpqiqFKeLpu5NwTIkVXUs48vFMwzqpqY4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1/go.mod h1:2DjTFR1HhMQhiWC5sZ4OhQ3+NtdbZ6oBDKQwq5Ou+FI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/precompile/multistaking/IMultiStaking.sol
+++ b/precompile/multistaking/IMultiStaking.sol
@@ -5,6 +5,14 @@ import "./Types.sol";
 
 enum BondStatus { Unbonded, Unbonding, Bonded }
 
+struct Description {
+    string moniker;
+    string identity;
+    string website;
+    string securityContact;
+    string details;
+}
+
 struct Validator {
     string operatorAddress;
     string consensusPubkey;
@@ -12,7 +20,7 @@ struct Validator {
     BondStatus status;
     uint256 tokens;
     uint256 delegatorShares;
-    string description;
+    Description description;
     int64 unbondingHeight;
     int64 unbondingTime;
     uint256 commission;

--- a/precompile/multistaking/abi.json
+++ b/precompile/multistaking/abi.json
@@ -335,9 +335,36 @@
               "type": "uint256"
             },
             {
-              "internalType": "string",
+              "components": [
+                {
+                  "internalType": "string",
+                  "name": "moniker",
+                  "type": "string"
+                },
+                {
+                  "internalType": "string",
+                  "name": "identity",
+                  "type": "string"
+                },
+                {
+                  "internalType": "string",
+                  "name": "website",
+                  "type": "string"
+                },
+                {
+                  "internalType": "string",
+                  "name": "securityContact",
+                  "type": "string"
+                },
+                {
+                  "internalType": "string",
+                  "name": "details",
+                  "type": "string"
+                }
+              ],
+              "internalType": "struct Description",
               "name": "description",
-              "type": "string"
+              "type": "tuple"
             },
             {
               "internalType": "int64",

--- a/precompile/multistaking/types.go
+++ b/precompile/multistaking/types.go
@@ -139,6 +139,15 @@ func NewValidatorRequest(args []interface{}) (*multistakingtypes.QueryValidatorR
 	return &multistakingtypes.QueryValidatorRequest{ValidatorAddr: validatorAddress}, nil
 }
 
+// Description use golang type alias defines a validator description.
+type Description = struct {
+	Moniker         string "json:\"moniker\""
+	Identity        string "json:\"identity\""
+	Website         string "json:\"website\""
+	SecurityContact string "json:\"securityContact\""
+	Details         string "json:\"details\""
+}
+
 // ValidatorInfo is a struct to represent the key information from
 // a validator response.
 type ValidatorInfo struct {
@@ -148,7 +157,7 @@ type ValidatorInfo struct {
 	Status            uint8    `abi:"status"`
 	Tokens            *big.Int `abi:"tokens"`
 	DelegatorShares   *big.Int `abi:"delegatorShares"` // TODO: Decimal
-	Description       string   `abi:"description"`
+	Description       stakingtypes.Description   `abi:"description"`
 	UnbondingHeight   int64    `abi:"unbondingHeight"`
 	UnbondingTime     int64    `abi:"unbondingTime"`
 	Commission        *big.Int `abi:"commission"`
@@ -170,7 +179,7 @@ func DefaultValidatorOutput() ValidatorOutput {
 			Status:            uint8(0),
 			Tokens:            big.NewInt(0),
 			DelegatorShares:   big.NewInt(0),
-			Description:       "",
+			Description:       stakingtypes.Description{},
 			UnbondingHeight:   int64(0),
 			UnbondingTime:     int64(0),
 			Commission:        big.NewInt(0),
@@ -195,7 +204,7 @@ func (vo *ValidatorOutput) FromResponse(res *multistakingtypes.QueryValidatorRes
 			Status:            uint8(stakingtypes.BondStatus_value[res.Validator.Status.String()]), //#nosec G115 // enum will always be convertible to uint8
 			Tokens:            res.Validator.Tokens.BigInt(),
 			DelegatorShares:   res.Validator.DelegatorShares.BigInt(),
-			Description:       res.Validator.Description.Details,
+			Description:       res.Validator.Description,
 			UnbondingHeight:   res.Validator.UnbondingHeight,
 			UnbondingTime:     res.Validator.UnbondingTime.UTC().Unix(),
 			Commission:        res.Validator.Commission.CommissionRates.Rate.BigInt(),

--- a/precompile/multistaking/types.go
+++ b/precompile/multistaking/types.go
@@ -151,18 +151,18 @@ type Description = struct {
 // ValidatorInfo is a struct to represent the key information from
 // a validator response.
 type ValidatorInfo struct {
-	OperatorAddress   string   `abi:"operatorAddress"`
-	ConsensusPubkey   string   `abi:"consensusPubkey"`
-	Jailed            bool     `abi:"jailed"`
-	Status            uint8    `abi:"status"`
-	Tokens            *big.Int `abi:"tokens"`
-	DelegatorShares   *big.Int `abi:"delegatorShares"` // TODO: Decimal
-	Description       stakingtypes.Description   `abi:"description"`
-	UnbondingHeight   int64    `abi:"unbondingHeight"`
-	UnbondingTime     int64    `abi:"unbondingTime"`
-	Commission        *big.Int `abi:"commission"`
-	MinSelfDelegation *big.Int `abi:"minSelfDelegation"`
-	BondDenom         string   `abi:"bondDenom"`
+	OperatorAddress   string                   `abi:"operatorAddress"`
+	ConsensusPubkey   string                   `abi:"consensusPubkey"`
+	Jailed            bool                     `abi:"jailed"`
+	Status            uint8                    `abi:"status"`
+	Tokens            *big.Int                 `abi:"tokens"`
+	DelegatorShares   *big.Int                 `abi:"delegatorShares"` // TODO: Decimal
+	Description       stakingtypes.Description `abi:"description"`
+	UnbondingHeight   int64                    `abi:"unbondingHeight"`
+	UnbondingTime     int64                    `abi:"unbondingTime"`
+	Commission        *big.Int                 `abi:"commission"`
+	MinSelfDelegation *big.Int                 `abi:"minSelfDelegation"`
+	BondDenom         string                   `abi:"bondDenom"`
 }
 
 type ValidatorOutput struct {

--- a/tests/integration/multistaking_integration_test.go
+++ b/tests/integration/multistaking_integration_test.go
@@ -357,7 +357,7 @@ func (suite *EVMTestSuite) TestMultistakingRemoveToken() {
 	coinsInf, err = multistakingClient.MultiStakingCoinInfos(suite.network.GetContext(), &multistakingtypes.QueryMultiStakingCoinInfosRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(len(coinsInf.Infos), 2)
-	
+
 	// Get unbonding delegation
 
 	ubdRes1, err := suite.network.GetStakingClient().ValidatorUnbondingDelegations(suite.network.GetContext(), &stakingtypes.QueryValidatorUnbondingDelegationsRequest{
@@ -416,18 +416,17 @@ func (suite *EVMTestSuite) TestMultistakingRemoveToken() {
 	suite.assertContractBalanceOf(contractAddr, val2Key.Addr, mintAmount)
 
 	// Also validator should be removed after that since all tokens are unbonded
-	val1Res, err = suite.network.GetStakingClient().Validator(suite.network.GetContext(), &stakingtypes.QueryValidatorRequest{
+	_, err = suite.network.GetStakingClient().Validator(suite.network.GetContext(), &stakingtypes.QueryValidatorRequest{
 		ValidatorAddr: validator1Address,
 	})
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "not found")
 
-	val2Res, err = suite.network.GetStakingClient().Validator(suite.network.GetContext(), &stakingtypes.QueryValidatorRequest{
+	_, err = suite.network.GetStakingClient().Validator(suite.network.GetContext(), &stakingtypes.QueryValidatorRequest{
 		ValidatorAddr: validator2Address,
 	})
 	suite.Require().Error(err)
 	suite.Require().Contains(err.Error(), "not found")
-
 }
 
 func (suite *EVMTestSuite) mintERC20(contractAddr common.Address, to common.Address, amount int64, privKey cryptotypes.PrivKey) {

--- a/tests/integration/multistaking_integration_test.go
+++ b/tests/integration/multistaking_integration_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"encoding/base64"
-	"fmt"
 	"math/big"
 
 	"cosmossdk.io/math"
@@ -747,7 +746,6 @@ func (suite *EVMTestSuite) cancelUndelegateEvm(contractAddr common.Address, send
 			CreationHeight:   creationHeight,
 		}},
 	})
-	fmt.Println("cancelResponse", cancelResponse, err)
 	suite.Require().NoError(err)
 	suite.Require().True(cancelResponse.IsOK(), "cancelUnbondingDelegation should have succeeded", cancelResponse.GetLog())
 	suite.Require().NoError(suite.network.NextBlock())

--- a/testutil/integration/utils/params.go
+++ b/testutil/integration/utils/params.go
@@ -92,3 +92,26 @@ func RegisterMultistakingEVMBondDenom(input UpdateParamsInput, contractAddr stri
 	}
 	return ApproveProposal(input.Tf, input.Network, input.Pk, proposalID)
 }
+
+func RemoveMultistakingBondDenom(input UpdateParamsInput, denom string, proposer sdk.AccAddress) error {
+	removeMultiStakingProposal := multistakingtypes.NewRemoveMultiStakingCoinProposal("tittle", "des", denom)
+
+	// Submit governance proposal
+	govMsg, err := govv1beta1.NewMsgSubmitProposal(
+		removeMultiStakingProposal,
+		sdk.NewCoins(sdk.NewCoin(input.Network.GetBaseDenom(), math.NewInt(1e18).Quo(evmtypes.GetEVMCoinDecimals().ConversionFactor()))),
+		proposer,
+	)
+	if err != nil {
+		return err
+	}
+
+	txArgs := commonfactory.CosmosTxArgs{
+		Msgs: []sdk.Msg{govMsg},
+	}
+	proposalID, err := submitProposal(input.Tf, input.Network, input.Pk, txArgs)
+	if err != nil {
+		return err
+	}
+	return ApproveProposal(input.Tf, input.Network, input.Pk, proposalID)
+}


### PR DESCRIPTION
integration test for https://github.com/realiotech/multi-staking/pull/153

Test scenario:
- create `rio` and `rst` validator
- create 2 validator more with an evm token
- users delegate to both 2 vals
- submit proposal to remove evm token as multistaking bonded token
- check undelegation for validator's self delegate and user delegate was created
- check evm token was returned to user after unbonding period
- check validator state after unbonding period